### PR TITLE
Remove Notice on lgin page

### DIFF
--- a/wax-custom-login.php
+++ b/wax-custom-login.php
@@ -56,7 +56,7 @@
 	 * @return  string             Return the current site title
 	 */
 
-	add_filter( 'login_headertitle', 'wax_login_logo_url_title' );
+	add_filter( 'login_headertext', 'wax_login_logo_url_title' );
 	function wax_login_logo_url_title() {
 		return get_bloginfo( 'name' );
 	}


### PR DESCRIPTION
Since WP 5.2, login_headertitle hook is deprectaded
use login_headertext instead